### PR TITLE
Fix non-semantic version for git dependencies (PACMAN-301)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Delete unused components from the `managed_components` directory
 - Fix include/exclude filters for nested paths in `idf_component.yml` manifest
 - Update lock file if new version of the idf was detected
+- Fix version check for components sourced from git
 
 ## [1.0.1] 2022-01-12
 

--- a/idf_component_tools/manifest/manifest.py
+++ b/idf_component_tools/manifest/manifest.py
@@ -184,8 +184,11 @@ class ComponentVersion(object):
 
         # Checking format
         if not (self.is_any or self.is_commit_id):
-            self._semver = semver.Version(self._version_string)
-            self.is_semver = True
+            try:
+                self._semver = semver.Version(self._version_string)
+                self.is_semver = True
+            except ValueError:
+                pass
 
     def __eq__(self, other):
         if hasattr(self, 'is_semver') and hasattr(other, 'is_semver') and self.is_semver and other.is_semver:


### PR DESCRIPTION
## Summary
If a git dependency is declared in an `idf_component.yml` with a version not formatted as `major.minor.patch[-prerelease]` (where major, minor and patch are integer numbers) a `ValueError: Invalid version string` is returned by the semantic_version package.

It's very common for git projects to have tags starting with `v` or release branches starting with `release-` and this error makes it
difficult to refer to a specific branch or tag. 

Because the `semantic-version.Version` call is used only to evaluate if the given version is semantic, the function should be surrounded by a `try / except` and move on if the given version is not in the semantic format.


## Impact
The current PR skips the blocking error generated if the version of a git dependency is not in the semantic format, making it possible to refer to a specific branch or tag as implied by `git_client.py:159`.
