### PR TITLE
Add manifest path option to support renamed main component (PACMAN-482)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,4 +37,7 @@ bandit_output.txt
 
 # Coverage reports
 .coverage
+.coverage.*
 coverage.xml
+
+.venv/

--- a/idf_component_manager/cli.py
+++ b/idf_component_manager/cli.py
@@ -116,7 +116,14 @@ def remove_managed_components(manager):
     manager.remove_managed_components()
 
 
-MANIFEST_COMPONENT_NAME_OPTION = [click.option('--component', default='main', help='Component name in the project')]
+MANIFEST_OPTIONS = [
+    click.option(
+        '--component',
+        default='main',
+        help='Component name in the project. Only main and components in the `components` directory are supported.'),
+    click.option(
+        '-p', '--path', default=None, help='Path of the component. Component name ignored when path specified.'),
+]
 
 
 @cli.group()
@@ -128,18 +135,18 @@ def manifest():
 
 
 @manifest.command()
-@add_options(PROJECT_DIR_OPTION + MANIFEST_COMPONENT_NAME_OPTION)
-def create(manager, component):
+@add_options(PROJECT_DIR_OPTION + MANIFEST_OPTIONS)
+def create(manager, component, path):
     """
     Create manifest file for the specified component.
     """
-    manager.create_manifest(component=component)
+    manager.create_manifest(component=component, path=path)
 
 
 @manifest.command()
-@add_options(PROJECT_DIR_OPTION + MANIFEST_COMPONENT_NAME_OPTION)
+@add_options(PROJECT_DIR_OPTION + MANIFEST_OPTIONS)
 @click.argument('dependency', required=True)
-def add_dependency(manager, component, dependency):
+def add_dependency(manager, component, path, dependency):
     """
     Add dependency to the manifest file. For now we only support adding dependencies from the component registry.
 
@@ -150,7 +157,7 @@ def add_dependency(manager, component, dependency):
     - $ compote manifest add-dependency example/cmp<=2.0.0
       would add component `example/cmp` with constraint `<=2.0.0`
     """
-    manager.add_dependency(dependency, component=component)
+    manager.add_dependency(dependency, component=component, path=path)
 
 
 @cli.group()
@@ -165,7 +172,7 @@ COMPONENT_VERSION_OPTION = [
     click.option(
         '--version',
         help='Set version if not defined in the manifest. Use "git" to get version from the git tag. '
-        '(command would fail if running not from a git tag)',
+             '(command would fail if running not from a git tag)',
     )
 ]
 
@@ -184,7 +191,7 @@ def pack(manager, namespace, name, version):  # noqa: namespace is not used
 @click.option(
     '--archive',
     help='Path of the archive with a component to upload. '
-    'When not provided the component will be packed automatically.',
+         'When not provided the component will be packed automatically.',
 )
 @click.option('--skip-pre-release', is_flag=True, default=False, help='Do not upload pre-release versions.')
 @click.option(

--- a/tests/test_cli.py
+++ b/tests/test_cli.py
@@ -18,11 +18,17 @@ def test_manifest_create_add_dependency(tmp_path, assert_return_code_run):
 
     os.makedirs(os.path.join(tempdir, 'main'))
     os.makedirs(os.path.join(tempdir, 'components', 'foo'))
+    os.makedirs(os.path.join(tempdir, 'src'))
     main_manifest_path = os.path.join(tempdir, 'main', MANIFEST_FILENAME)
     foo_manifest_path = os.path.join(tempdir, 'components', 'foo', MANIFEST_FILENAME)
+    src_path = os.path.join(tempdir, 'src')
+    src_manifest_path = os.path.join(src_path, MANIFEST_FILENAME)
 
     assert_return_code_run(['compote', 'manifest', 'create'], cwd=tempdir)
     assert_return_code_run(['compote', 'manifest', 'create', '--component', 'foo'], cwd=tempdir)
+    assert_return_code_run(['compote', 'manifest', 'create', '--path', src_path], cwd=tempdir)
+    assert_return_code_run(
+        ['compote', 'manifest', 'create', '--component', 'src', '--path', src_path], cwd=tempdir, code=2)
 
     for filepath in [main_manifest_path, foo_manifest_path]:
         with open(filepath, mode='r') as file:
@@ -35,4 +41,9 @@ def test_manifest_create_add_dependency(tmp_path, assert_return_code_run):
     assert_return_code_run(
         ['compote', 'manifest', 'add-dependency', 'idf/comp<=1.0.0', '--component', 'foo'], cwd=tempdir)
     manifest_manager = ManifestManager(foo_manifest_path, 'foo')
+    assert manifest_manager.manifest_tree['dependencies']['idf/comp'] == '<=1.0.0'
+
+    assert_return_code_run(
+        ['compote', 'manifest', 'add-dependency', 'idf/comp<=1.0.0', '--path', src_path], cwd=tempdir)
+    manifest_manager = ManifestManager(src_manifest_path, 'src')
     assert manifest_manager.manifest_tree['dependencies']['idf/comp'] == '<=1.0.0'

--- a/tests/test_component_manager.py
+++ b/tests/test_component_manager.py
@@ -6,6 +6,7 @@ import shutil
 import tempfile
 from distutils.dir_util import copy_tree
 from io import open
+from pathlib import Path
 
 import pytest
 import vcr
@@ -29,15 +30,30 @@ def list_dir(folder):
 
 def test_init_project():
     tempdir = tempfile.mkdtemp()
+
     try:
         os.makedirs(os.path.join(tempdir, 'main'))
         os.makedirs(os.path.join(tempdir, 'components', 'foo'))
+        os.makedirs(os.path.join(tempdir, 'src'))
         main_manifest_path = os.path.join(tempdir, 'main', MANIFEST_FILENAME)
         foo_manifest_path = os.path.join(tempdir, 'components', 'foo', MANIFEST_FILENAME)
+        src_path = os.path.join(tempdir, 'src')
+        src_manifest_path = os.path.join(src_path, MANIFEST_FILENAME)
+
+        outside_project_path = str(Path(tempdir).parent)
+        outside_project_path_error_match = 'Directory ".*" is not under project directory!'
+        component_and_path_error_match = 'Cannot determine manifest directory.'
 
         manager = ComponentManager(path=tempdir)
         manager.create_manifest()
         manager.create_manifest(component='foo')
+        manager.create_manifest(path=src_path)
+
+        with pytest.raises(FatalError, match=outside_project_path_error_match):
+            manager.create_manifest(path=outside_project_path)
+
+        with pytest.raises(FatalError, match=component_and_path_error_match):
+            manager.create_manifest(component='src', path=src_path)
 
         for filepath in [main_manifest_path, foo_manifest_path]:
             with open(filepath, mode='r') as file:
@@ -50,6 +66,16 @@ def test_init_project():
         manager.add_dependency('idf/comp<=1.0.0', component='foo')
         manifest_manager = ManifestManager(foo_manifest_path, 'foo')
         assert manifest_manager.manifest_tree['dependencies']['idf/comp'] == '<=1.0.0'
+
+        manager.add_dependency('idf/comp<=1.0.0', path=src_path)
+        manifest_manager = ManifestManager(src_manifest_path, 'src')
+        assert manifest_manager.manifest_tree['dependencies']['idf/comp'] == '<=1.0.0'
+
+        with pytest.raises(FatalError, match=outside_project_path_error_match):
+            manager.create_manifest(path=outside_project_path)
+
+        with pytest.raises(FatalError, match=component_and_path_error_match):
+            manager.add_dependency('idf/comp<=1.0.0', component='src', path=src_path)
     finally:
         shutil.rmtree(tempdir)
 


### PR DESCRIPTION
## Summary

This PR adds a component path option to manifest commands to support renamed main components as well as custom component paths.

```shell
# Add lvgl to main component renamed to src
compote manifest add-dependency lvgl/lvgl>=8.* --component-path /project/src
```

This PR resolves https://github.com/espressif/idf-component-manager/issues/9.

## Impact

This PR should not impact any existing functionality as the new component path argument is optional and if not specified uses the default component directory path. Unit tests are included to check the existing functionality as well as the new functionality.

## Related links

- https://github.com/espressif/idf-component-manager/issues/9

